### PR TITLE
chore: remove org and app from serverless.yaml

### DIFF
--- a/serverless.yaml
+++ b/serverless.yaml
@@ -1,7 +1,3 @@
-# "org" ensures this Service is used with the correct Serverless Framework Access Key.
-org: interchainexplorer
-# "app" enables Serverless Framework Dashboard features and sharing them with other Services.
-app: interchain-explorer
 # "app" enables Serverless Framework Dashboard features and sharing them with other Services.
 service: interchain-explorer
 


### PR DESCRIPTION
* removed `org` and `app` properties from `serverless.yaml` in order to resolve below issue while deploying
```
"ap-northeast-2" region is not supported by dashboard
```