### PR TITLE
fix: 보내는쪽 transaction value 수정 

### DIFF
--- a/src/api/api.service.ts
+++ b/src/api/api.service.ts
@@ -831,8 +831,10 @@ export class ApiService {
   private async getUsdcTransferLogsInSource(chain: string, depositorAddress: string, recipientAddress: string, logs) {
     const transferCode = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
     const filteredLog = logs
-      .filter(log => log.topics[0] === transferCode && '0x' + log.topics[1].slice(-40).toLowerCase() === recipientAddress.toLowerCase()
-        && '0x' + log.topics[2].slice(-40).toLowerCase() === depositorAddress.toLowerCase() && log.address.toLowerCase() === USDC_ADDRESSES_MAP[chain]);
+      .filter(log => log.topics[0] === transferCode
+        && log.address.toLowerCase() === USDC_ADDRESSES_MAP[chain]
+        && '0x' + log.topics[1].slice(-40).toLowerCase() === recipientAddress
+        && '0x' + log.topics[2].slice(-40).toLowerCase() === depositorAddress);
     return filteredLog[0];
   }
 
@@ -842,7 +844,7 @@ export class ApiService {
     const srcTx = await this.getTxReceipt(srcHash, srcChain);
     const srcTimeStamp = new Date(txInfo.from_timestamp).getTime();
     const depositorAddress = txInfo.from;
-    const sourceLogs = await this.getUsdcTransferLogsInSource(srcChain, depositorAddress, txInfo.destination, srcTx.logs);
+    const sourceLogs = await this.getUsdcTransferLogsInSource(srcChain, depositorAddress.toLowerCase(), txInfo.destination.toLowerCase(), srcTx.logs);
     let inputAmount = txInfo.amount;
     if (sourceLogs) inputAmount = BigInt(parseInt(sourceLogs.data, 16)).toString();
     const sourceTx = {

--- a/src/api/api.service.ts
+++ b/src/api/api.service.ts
@@ -921,7 +921,8 @@ export class ApiService {
         chain: srcChain,
         value: inputAmount,
         timestamp: srcTimeStamp,
-        hash: srcTx,};
+        hash: srcTx,
+      };
 
       const destChain = jsonData.destination_network;
       const destHash = jsonData.transfer_hash;
@@ -953,7 +954,7 @@ export class ApiService {
 
       console.log(crawlResponse);
       return crawlResponse;
-    }catch (error: any) {
+    } catch (error: any) {
       console.error('Error fetching or parsing HTML:', error.message);
       return null;
     }

--- a/src/api/api.service.ts
+++ b/src/api/api.service.ts
@@ -9,6 +9,8 @@ import { ETHEREUM_API_KEY, BNBSCAN_API_KEY, INFURA_API_KEY, ARBITRUM_API_KEY, BA
 import axios from 'axios';
 import * as cheerio from 'cheerio';
 import { LayerZeroError, CCTPapiError } from '../errors';
+import { USDC_ADDRESSES_MAP } from "../common/usdc-address";
+
 @Injectable()
 export class ApiService {
   private mainnetProvider = new InfuraProvider("mainnet", INFURA_API_KEY);
@@ -826,12 +828,23 @@ export class ApiService {
     return data.resources[0];
   }
 
+  private async getUsdcTransferLogsInSource(chain: string, depositorAddress: string, recipientAddress: string, logs) {
+    const transferCode = '0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef';
+    const filteredLog = logs
+      .filter(log => log.topics[0] === transferCode && '0x' + log.topics[1].slice(-40).toLowerCase() === recipientAddress.toLowerCase()
+        && '0x' + log.topics[2].slice(-40).toLowerCase() === depositorAddress.toLowerCase() && log.address.toLowerCase() === USDC_ADDRESSES_MAP[chain]);
+    return filteredLog[0];
+  }
+
   async getRecipientTxListFromCCTP(txInfo) {
-    const srcTx = txInfo.burn_hash;
     const srcChain = txInfo.from_network;
+    const srcHash = txInfo.burn_hash
+    const srcTx = await this.getTxReceipt(srcHash, srcChain);
     const srcTimeStamp = new Date(txInfo.from_timestamp).getTime();
     const depositorAddress = txInfo.from;
-    const inputAmount = txInfo.amount;
+    const sourceLogs = await this.getUsdcTransferLogsInSource(srcChain, depositorAddress, txInfo.destination, srcTx.logs);
+    let inputAmount = txInfo.amount;
+    if (sourceLogs) inputAmount = BigInt(parseInt(sourceLogs.data, 16)).toString();
     const sourceTx = {
       "address": depositorAddress,
       "id": 'USDC',
@@ -839,7 +852,7 @@ export class ApiService {
       "chain": srcChain,
       "value": inputAmount,
       "timestamp": srcTimeStamp,
-      "hash": srcTx
+      "hash": srcHash
     };
     const destChain = txInfo.destination_network;
     const destHash = txInfo.transfer_hash;
@@ -850,7 +863,7 @@ export class ApiService {
       "id": 'USDC',
       "name": 'USDC',
       "chain": destChain,
-      "value": inputAmount,
+      "value": txInfo.amount,
       "timestamp": destTimeStamp,
       "hash": destHash
     };
@@ -906,8 +919,8 @@ export class ApiService {
         chain: srcChain,
         value: inputAmount,
         timestamp: srcTimeStamp,
-        hash: srcTx,
-      };
+        hash: srcTx,};
+
       const destChain = jsonData.destination_network;
       const destHash = jsonData.transfer_hash;
       const destTimeStamp = new Date(jsonData.destination_timestamp).getTime();
@@ -938,7 +951,7 @@ export class ApiService {
 
       console.log(crawlResponse);
       return crawlResponse;
-    } catch (error: any) {
+    }catch (error: any) {
       console.error('Error fetching or parsing HTML:', error.message);
       return null;
     }

--- a/src/common/usdc-address.ts
+++ b/src/common/usdc-address.ts
@@ -1,0 +1,5 @@
+export const USDC_ADDRESSES_MAP: { [key: string]: string } = {
+  'ethereum': '0xa0b86991c6218b36c1d19d4a2e9eb0ce3606eb48',
+  'base': '0x833589fcd6edb6e08f4c7c32d4f71b54bda02913',
+  'arbitrum': '0xaf88d065e77c8cc2239327c5edb3a432268e5831'
+};


### PR DESCRIPTION
**기존 문제: 보내는쪽, 받는쪽 USDC value값이 둘다 받는쪽 value로 나오고 있었음**
- 보내는쪽 value값 구하는 로직 추가 (transaction log에서 Mathod=transfer, from, to 주소를 확인하여 해당거래의 value data 가져옴) 

**예외케이스 발견** 
https://usdc.range.org/usdc/status/0x556eb3b5f5fc5620100afa46c4f6643cb620cde7cab431e969da10d82213cbd7

해당 케이스는 한 트랜잭션에 여러 token이 전송된 경우로 로그에서 sender address, receiver address, Mathod=transfer 로 필터를 걸어 찾아도 Pepe coin이 나옴 

→ Circle address 조건을 추가해 보았지만, Circle 거래로그에 sender, receiver address가 달라 조건에 걸리지 않음 
→ 한 트랜잭션에 여러 거래가 있는 경우 log로 모든 케이스를 다 커버하는게 힘들다고 판단 
따라서 sender address, receiver address, Mathod=transfer, Circle address 를 조건걸어서 value값을 찾고 없는 경우는 도착지 value값과 같게 처리했습니다. 


**테스트 케이스**
- https://usdc.range.org/usdc/status/0xc0d42dd4e9ce612fbff5187015105faa8331c5a4207100cb8b00147ac4f64ff6

**결과**
<img width="617" alt="image" src="https://github.com/user-attachments/assets/1df0e0e3-6205-4290-b04f-d9693df10a98" />
