### PR TITLE
Fix: 이후 transactions 가져올때 수정 - filter 적용

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -389,8 +389,12 @@
   `;
       // Create source transaction details
       let sourceValue;
+      const formatter = new Intl.NumberFormat('en-US', {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 6
+      });
       if(protocol === 'CCTP'){
-        sourceValue = (Number(sourceTx.value) / 1e6).toFixed(6);
+        sourceValue = formatter.format(Number(sourceTx.value) / 1e6);
       }else{
         sourceValue = Number((Number(sourceTx.value) / 10**18).toFixed(4)).toLocaleString();
       }
@@ -406,7 +410,7 @@
       // Create destination transaction details
       let destinationValue;
       if(protocol === 'CCTP'){
-        destinationValue = (Number(destinationTx.value) / 1e6).toFixed(6);
+        destinationValue = formatter.format(Number(destinationTx.value) / 1e6);
       }else{
         destinationValue =  Number((Number(destinationTx.value) / 10**18).toFixed(4)).toLocaleString();
       }

--- a/src/api/api.service.ts
+++ b/src/api/api.service.ts
@@ -711,6 +711,7 @@ export class ApiService {
     if (data.result.length > 0) {
       return data.result.map((tx: any) => ({ ...tx, chain: chainName }));
     } else {
+      console.log("No transactions afterwards on the destination chain.");
       return '';
     }
   }


### PR DESCRIPTION
**피드백**
: "브릿지 이후의 tx들" 부분에서 표시되는 tx들은, **USDC receiver가 from인 tx**가 표시되어야 합니다. 그런데 tx에 따라 결과가 다르게 나오네요. 아래 확인해주시고 고치면 좋겠습니다.
- 의도대로 표시되는 tx hash: `0x29f83c7416ced483588a8db88057bdc64ca6dc74732575f1376cf032d3b1e966`
- 다른 tx가 표시되는 (receiver로 표시되는 주소가 to인 tx들?) tx hash: `0x33a6efd2d5dc0b012dce53d8fc6a4fcf608cb20bd2bc087b1fe733c2e129faaa`

**기존 코드:** receiver의 이후 트랜잭션들을 가져오는 getTxListByAddress에서 받는쪽 blocknumber 이후 트랜잭션들을 incoming, outgoing 구분없이 5개를 가져오고 있었음 

**수정 사항: 트랜잭션을 가져올때 filter로 USDC receiver가 from인 것만 가져오게 변경** 


**테스트** 
- 0x33a6efd2d5dc0b012dce53d8fc6a4fcf608cb20bd2bc087b1fe733c2e129faaa
  - 피드백에 알려주셨던 케이스로, USDC를 받은 이후 Incoming 트랜잭션들 뿐이므로 결과값 없음 

- 0xda26de06649354d4baa4b7ab902abb1f9924b63ef1bea1ebf97a88833a415492
  - arbitrum → Ethereum
  - 이후 첫번째 트랜잭션을 살펴보면 Incoming Tx인 [21444553](https://etherscan.io/block/21444553)이 아닌 Outgoing Tx [21444574](https://etherscan.io/block/21444574)가져오는것 확인 

**LaterZero case**
- 0xab08c88cc886d736ae74bd60360c7205ee66c94922f28b9c158d23e49a10b321
  - 4번째 트랜잭션을 보면 기존에는 [280228605](https://arbiscan.io/block/280228605) Incoming Transaction이었으나, 수정후에는 [280229631](https://arbiscan.io/block/280229631) 으로 나옴 